### PR TITLE
feat: add Apps section with new components and translations

### DIFF
--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -151,6 +151,25 @@
       "title": "Posts",
       "description": "I write about my experiences and learnings in the software engineering field."
     },
+    "apps": {
+      "title": "Apps",
+      "musicPlayer": {
+        "name": "Music Player",
+        "description": "Listen to a curated playlist."
+      },
+      "inspirations": {
+        "name": "Inspirations",
+        "description": "Collection of ideas and references that inspire."
+      },
+      "bookmarks": {
+        "name": "Bookmarks",
+        "description": "Saved links and resources."
+      },
+      "photos": {
+        "name": "Photos",
+        "description": "Photo gallery and visual snapshots."
+      }
+    },
     "infoBlock": {
       "pointer": {
         "text": "Hey, What's up?"

--- a/apps/www/src/app/page.tsx
+++ b/apps/www/src/app/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from 'next';
 import { useTranslations } from 'next-intl';
 import { getTranslations } from 'next-intl/server';
 
+import AppsBlock from '@/components/apps-block';
 import InfoBlock from '@/components/info-block';
 import PageContainer from '@/components/layout/page-container';
 import { Section } from '@/components/layout/section';
@@ -44,8 +45,11 @@ export default function Page() {
       <Section isFirstSection>
         <InfoBlock />
       </Section>
-      <Section isLastSection title={t('Blocks.posts.title')}>
+      <Section title={t('Blocks.posts.title')}>
         <PostsBlock />
+      </Section>
+      <Section isLastSection title={t('Blocks.apps.title')}>
+        <AppsBlock />
       </Section>
     </PageContainer>
   );

--- a/apps/www/src/components/apps-block.tsx
+++ b/apps/www/src/components/apps-block.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+
+import { cn } from '@/lib/utils';
+
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/tooltip';
+
+const APP_IDS = ['musicPlayer', 'inspirations', 'bookmarks', 'photos'] as const;
+const APP_LETTERS: Record<(typeof APP_IDS)[number], string> = {
+  musicPlayer: 'MP',
+  inspirations: 'IN',
+  bookmarks: 'BM',
+  photos: 'PH',
+};
+const APP_HREFS: Record<(typeof APP_IDS)[number], string> = {
+  musicPlayer: '/music',
+  inspirations: '/inspirations',
+  bookmarks: '/bookmarks',
+  photos: '/photos',
+};
+
+export default function AppsBlock() {
+  const t = useTranslations('Blocks.apps');
+
+  return (
+    <div className="hidden md:block">
+      <TooltipProvider delayDuration={300}>
+        <div className="border-border bg-card rounded-xl border p-4">
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+            {APP_IDS.map(id => (
+              <Tooltip key={id}>
+                <TooltipTrigger asChild>
+                  <Link
+                    href={APP_HREFS[id]}
+                    className="flex flex-col items-center gap-2 transition-colors"
+                  >
+                    <span
+                      className={cn(
+                        'bg-muted text-foreground hover:bg-primary hover:text-primary-foreground flex size-14 items-center justify-center rounded-lg text-lg font-bold tracking-tight transition-colors',
+                      )}
+                    >
+                      {APP_LETTERS[id]}
+                    </span>
+                    <span className="text-muted-foreground line-clamp-2 text-center text-sm tracking-tight">
+                      {t(`${id}.name`)}
+                    </span>
+                  </Link>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="max-w-[200px]">
+                  {t(`${id}.description`)}
+                </TooltipContent>
+              </Tooltip>
+            ))}
+          </div>
+        </div>
+      </TooltipProvider>
+    </div>
+  );
+}


### PR DESCRIPTION
- Introduced a new Apps section in the application, featuring components for Music Player, Inspirations, Bookmarks, and Photos.
- Updated translations in en.json to include titles and descriptions for the new Apps section.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds a new home page section and translation strings; main risk is broken navigation if the new routes don’t exist.
> 
> **Overview**
> Adds a new **Apps** section to the home page, placed after Posts, and adjusts section padding by moving `isLastSection` from Posts to Apps.
> 
> Introduces a new client-side `AppsBlock` grid (desktop-only) that links to `/music`, `/inspirations`, `/bookmarks`, and `/photos` with tooltip descriptions, and adds the corresponding `Blocks.apps` translation entries in `en.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9de16ffec1c8ec163b2360099e4527d86a8b25ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->